### PR TITLE
Add values at initialization via the constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,19 @@ class InfinitySet<T> {
 
   /* CONSTRUCTOR */
 
-  constructor () {
+  constructor (values?: Iterable<T> | null) {
 
     this.clear ();
+
+    if (values != null && Symbol.iterator in values) {
+
+      for (const value of values) {
+
+        this.add(value)
+
+      }
+
+    }
 
   }
 


### PR DESCRIPTION
`Set` allows values to be added at initialization by passing an iterable to the constructor

```js
new InfinitySet([])
new InfinitySet(new Map())
new InfinitySet(Object.values({}))
new InfinitySet(Object.keys({}))
// etc...
```